### PR TITLE
Tagged autofs-config tasks as "postboot"

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,6 +1,6 @@
 ---
 - name: Copy main autofs file
-  tags: postboot
+  tags: postboot postboot-autofs
   ansible.builtin.template:
     src: data.autofs.j2
     dest: "/etc/auto.master.d/data.autofs"
@@ -11,7 +11,7 @@
   when: (autofs_mount_points is defined) and (autofs_mount_points|length > 0)
 
 - name: Copy mount point configuration file
-  tags: postboot
+  tags: postboot postboot-autofs
   ansible.builtin.template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -27,7 +27,7 @@
   notify: autofs restart
 
 - name: autofs service enable
-  tags: postboot
+  tags: postboot postboot-autofs
   ansible.builtin.service:
     name: autofs
     enabled: yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,5 +1,6 @@
 ---
 - name: Copy main autofs file
+  tags: postboot
   ansible.builtin.template:
     src: data.autofs.j2
     dest: "/etc/auto.master.d/data.autofs"
@@ -10,6 +11,7 @@
   when: (autofs_mount_points is defined) and (autofs_mount_points|length > 0)
 
 - name: Copy mount point configuration file
+  tags: postboot
   ansible.builtin.template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -25,6 +27,7 @@
   notify: autofs restart
 
 - name: autofs service enable
+  tags: postboot
   ansible.builtin.service:
     name: autofs
     enabled: yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,6 +1,8 @@
 ---
 - name: Copy main autofs file
-  tags: postboot postboot-autofs
+  tags: 
+    - postboot
+    - postboot-autofs
   ansible.builtin.template:
     src: data.autofs.j2
     dest: "/etc/auto.master.d/data.autofs"
@@ -11,7 +13,9 @@
   when: (autofs_mount_points is defined) and (autofs_mount_points|length > 0)
 
 - name: Copy mount point configuration file
-  tags: postboot postboot-autofs
+  tags: 
+    - postboot
+    - postboot-autofs
   ansible.builtin.template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -27,7 +31,9 @@
   notify: autofs restart
 
 - name: autofs service enable
-  tags: postboot postboot-autofs
+  tags: 
+    - postboot
+    - postboot-autofs
   ansible.builtin.service:
     name: autofs
     enabled: yes


### PR DESCRIPTION
This PR flags the autofs config tasks as "postboot" by adding this tag. The idea is to be able to run these (and later possibly other) tasks selectively on a running host in order to update the autofs maps on-the-fly.