### PR TITLE
add cache and misc volume templates to autofs conf

### DIFF
--- a/templates/data.conf.j2
+++ b/templates/data.conf.j2
@@ -25,3 +25,17 @@
 {{ row }}
 {% endfor %}
 {% endif %}
+
+# Cache volumes
+{% if "cache" in autofs_mount_points %}
+{% for row in autofs_conf_files.cache %}
+{{ row }}
+{% endfor %}
+{% endif %}
+
+# Misc volumes
+{% if "misc" in autofs_mount_points %}
+{% for row in autofs_conf_files.misc %}
+{{ row }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
We must update the templates to mount `misc` and `cache` via autofs.