### PR TITLE
remove explicit definition of nfsversion in the autofs configuration

### DIFF
--- a/templates/data.autofs.j2
+++ b/templates/data.autofs.j2
@@ -1,9 +1,9 @@
 {% if "data" in autofs_mount_points %}
-/data           /etc/auto.data          nfsvers=3
+/data           /etc/auto.data
 {% endif %}
 {% if "discontinued" in autofs_mount_points %}
-/discontinued   /etc/auto.discontinued  nfsvers=3
+/discontinued   /etc/auto.discontinued
 {% endif %}
 {% if "usrlocal" in autofs_mount_points or "usrlocal_celerycluster" in autofs_mount_points %}
-/-              /etc/auto.usrlocal      nfsvers=3
+/-              /etc/auto.usrlocal
 {% endif %}


### PR DESCRIPTION
This PR removes the explicitly defining `nfsvers=3` in the autofs conf. In its absence, NFS autonegotiates for the best version. Further, we can control the version if we would like via the `nfs_options` in the [mounts repo](https://github.com/usegalaxy-eu/mounts/blob/main/mountpoints.yml) for each mount. 

Once this is merged we need to make a new release and update the version in [playbook requirements file](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/master/requirements.yaml#L117-L119).