### PR TITLE
Add cvac volume templates to autofs conf

### DIFF
--- a/templates/data.conf.j2
+++ b/templates/data.conf.j2
@@ -33,6 +33,13 @@
 {% endfor %}
 {% endif %}
 
+# CVMFS alien cache volumes
+{% if "cvac" in autofs_mount_points %}
+{% for row in autofs_conf_files.cvac %}
+{{ row }}
+{% endfor %}
+{% endif %}
+
 # Misc volumes
 {% if "misc" in autofs_mount_points %}
 {% for row in autofs_conf_files.misc %}


### PR DESCRIPTION
Include CVMFS alien cache volume templates in the autofs configuration. Required to mount the new share `/data/cvmfs08` that will be used exclusively to store the CVMFS alien cache on NFS.